### PR TITLE
feat(build): make `npm run build` work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
     "lint:lib": "tslint src/**/*.ts",
     "lint:spec": "tslint spec/**/*.ts",
     "clean": "npm-run-all clean:*",
-    "clean:release": "rm -rf ./release",
+    "clean:release": "rimraf ./release",
     "prebuild": "npm-run-all clean test",
     "build": "npm-run-all build:cjs build:esm",
     "build:cjs": "ngc --p tsconfig.json",
     "build:esm": "ngc -p tsconfig.esm.json",
     "prepare": "npm-run-all prepare:*",
-    "prepare:ts": "cp -R ./src ./release",
-    "prepare:package": "cp ./{package.json,README.md,LICENSE} ./release",
+    "prepare:ts": "cpx ./src/** ./release/src/",
+    "prepare:package": "cpx {./package.json,./README.md,./LICENSE} ./release",
     "test": "echo 'Tests not implemented'",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "postbuild": "npm run prepare",
@@ -72,5 +72,9 @@
     "ts-loader": "^0.8.1",
     "tslint": "^3.6.0",
     "typescript": "^2.0.0"
+  },
+  "dependencies": {
+    "cpx": "^1.3.2",
+    "rimraf": "^2.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,14 +67,12 @@
     "@ngrx/store-devtools": "^2.0.0-beta.1",
     "conventional-changelog-cli": "^1.1.1",
     "core-js": "^2.2.2",
+    "cpx": "^1.3.2",
     "npm-run-all": "^3.0.0",
+    "rimraf": "^2.5.4",
     "rxjs": "5.0.0-beta.6",
     "ts-loader": "^0.8.1",
     "tslint": "^3.6.0",
     "typescript": "^2.0.0"
-  },
-  "dependencies": {
-    "cpx": "^1.3.2",
-    "rimraf": "^2.5.4"
   }
 }


### PR DESCRIPTION
Even if you might have GnuWin32 installed (and that is not mentioned), not all commands run successfully. E.g. `cp ./{package.json,README.md,LICENSE} ./release` fails.
