### PR TITLE
chore(deps): upgrade angular2 RC1 deps to RC5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,12 +55,12 @@
     "@ngrx/store-devtools": "^3.0.0"
   },
   "devDependencies": {
-    "@angular/common": "^2.0.0-rc.1",
+    "@angular/common": "^2.0.0-rc.5",
     "@angular/compiler": "^2.0.0-rc.5",
     "@angular/compiler-cli": "^0.5.0",
-    "@angular/core": "^2.0.0-rc.1",
+    "@angular/core": "^2.0.0-rc.5",
     "@angular/platform-browser": "^2.0.0-rc.5",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.5",
     "@angular/platform-server": "^2.0.0-rc.5",
     "@ngrx/core": "^1.0.0",
     "@ngrx/store": "^2.0.0",


### PR DESCRIPTION
Or is there a specific reason why some dependencies were left at RC1 ?
